### PR TITLE
Switching to consistent constituent abbreviations

### DIFF
--- a/data/discqw.RData
+++ b/data/discqw.RData
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:220060e97f90d14290ee1c50162e44b3c22c0e23d0a59039b30d2ac95ea48df9
-size 339288
+oid sha256:1338761060fa8d027c248bddcc2473f9bb5fd7e141d85e97c76b6fd744fba478
+size 339296

--- a/tests/testthat/test_non_pesticide_time_series.R
+++ b/tests/testthat/test_non_pesticide_time_series.R
@@ -1,0 +1,29 @@
+library(validate)
+library(testthat)
+context("non-pesticide time series")
+
+test_that("constituent abbreviations are consistent", {
+	
+	all_non_pesticide_data_frame_names_with_constituents <- c('aloads', 'mloads', 'discqw')
+	
+	expected_constituents <- sort(c("TP", "TN", "SSC", "NO3_NO2"))
+	
+	actual_constituents_list <- Map(function(data_frame_name){
+		returnList <- levels(get(data_frame_name)$CONSTIT)
+		attr(returnList, 'data_frame_name') <- data_frame_name
+		return(returnList)
+	}, all_non_pesticide_data_frame_names_with_constituents)
+	
+	Map(function(actual_constituents){
+		matches <- actual_constituents %in% expected_constituents
+		if (!all(matches)) {
+			msg <- "Did not find all of ("
+			msg <- paste(msg, paste(sort(unlist(actual_constituents)), collapse = ", "))
+			msg <- paste(msg, ") in the expected list of constituents (")
+			msg <- paste(msg, paste(expected_constituents, collapse = ", "))
+			msg <- paste(msg, ") for the data frame", attr(actual_constituents, 'data_frame_name'))
+			fail(msg)
+		}
+		
+	}, actual_constituents_list)
+})

--- a/tests/testthat/test_non_pesticide_time_series.R
+++ b/tests/testthat/test_non_pesticide_time_series.R
@@ -26,4 +26,6 @@ test_that("constituent abbreviations are consistent", {
 		}
 		
 	}, actual_constituents_list)
-})
+	#if it didn't fail yet, then it must have succeeded
+	succeed()
+	})


### PR DESCRIPTION
before:
```
table(discqw$CONSTIT)

 NO23   SSC    TN    TP
23516 20291 18638 22859
```

after:
```
discqw$CONSTIT <- droplevels(discqw$CONSTIT)

    SSC      TN      TP NO3_NO2 
  20291   18638   22859   23516 
```