### PR TITLE
Copied test about mandatory sites from mloads tests into aloads tests.

### DIFF
--- a/tests/testthat/test_annual_load.R
+++ b/tests/testthat/test_annual_load.R
@@ -11,6 +11,8 @@ temp_aloads$YIELD_N<-as.numeric(temp_aloads$YIELD)
 temp_aloads$mod1<-as.character(temp_aloads$MODTYPE)
 temp_aloads[temp_aloads$mod1%in%"REGHIST","mod1"]<-"REG"
 
+
+
 #looking for more thorough explanation of the 'validate' library capabilities?
 #Run:
 # vignette("intro", package="validate")
@@ -105,4 +107,10 @@ test_that("There are no duplicate values", {
   
 })
 
-
+test_that("Most recent water year has all of the necessary sites ", {
+  temp_aloads_recent<-temp_aloads[temp_aloads$WY %in% max(temp_aloads$WY),] 
+  expected <- sort(c("HAZL","PADU","GRAN","CLIN","WAPE","KEOS","VALL","GRAF","SIDN","OMAH","ELKH","LOUI","DESO","HERM","THEB","SEDG","HARR","LITT","KERS",
+                     "STFR","BATO","BELL","MELV","CALU","MORG","SUMN","STTH","GULF","NEWH","CANN","MISS"))
+  actual <- sort(unique(temp_aloads_recent$SITE_ABB))
+  expect_equal(actual, expected)
+})


### PR DESCRIPTION
Hi @supercasey! Annual Load Data are missing for the GULF site in the most recent water year. Do you think this is a reasonable test to add to detect things like this going forward?